### PR TITLE
Display cart sidebar on all pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import NotFound from "./pages/NotFound";
 import OrderStatus from "./pages/OrderStatus";
 import { setupMockFetch } from "@/lib/mock-api";
 import { CartProvider } from "@/contexts/CartContext";
+import { CartSidebar } from "@/components/cart/CartSidebar";
 
 const queryClient = new QueryClient();
 
@@ -37,6 +38,7 @@ const App = () => (
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>
+          <CartSidebar />
         </BrowserRouter>
       </TooltipProvider>
     </CartProvider>

--- a/src/components/cart/CartSidebar.tsx
+++ b/src/components/cart/CartSidebar.tsx
@@ -5,10 +5,21 @@ import { Separator } from "@/components/ui/separator";
 import { useCart } from "@/contexts/CartContext";
 import { formatIndianCurrency } from "@/lib/currency";
 import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
 
 export function CartSidebar() {
   const { state, dispatch, removeFromCart, updateQuantity, clearCart, getCartTotal, getCartCount } = useCart();
   const navigate = useNavigate();
+  
+  useEffect(() => {
+    if (state.isOpen) {
+      const original = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = original;
+      };
+    }
+  }, [state.isOpen]);
 
   const handleCheckout = () => {
     navigate('/checkout', { 
@@ -29,12 +40,17 @@ export function CartSidebar() {
     <>
       {/* Backdrop */}
       <div 
-        className="fixed inset-0 bg-black/50 z-40"
+        className="fixed inset-0 bg-black/50 z-[60]"
         onClick={() => dispatch({ type: 'CLOSE_CART' })}
       />
       
       {/* Cart Sidebar */}
-      <div className="fixed right-0 top-0 h-full w-full max-w-md bg-background shadow-2xl z-50 transform transition-transform duration-300 ease-in-out">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Shopping cart"
+        className="fixed right-0 top-0 h-full w-full max-w-md bg-background shadow-2xl z-[70] transform transition-transform duration-300 ease-in-out"
+      >
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="flex items-center justify-between p-6 border-b">

--- a/src/components/home/TodaySpecials.tsx
+++ b/src/components/home/TodaySpecials.tsx
@@ -4,11 +4,26 @@ import { useCart } from "@/contexts/CartContext";
 import { formatIndianCurrency } from "@/lib/currency";
 import { useNavigate } from "react-router-dom";
 
+interface SpecialItem {
+  id: number;
+  name: string;
+  description: string;
+  price: number;
+  originalPrice: number;
+  image: string;
+  rating: number;
+  cookTime: string;
+  isSpicy: boolean;
+  discount: string;
+  category: string;
+  isVeg: boolean;
+}
+
 export function TodaySpecials() {
   const { addToCart } = useCart();
   const navigate = useNavigate();
 
-  const specials = [
+  const specials: SpecialItem[] = [
     {
       id: 1,
       name: "Truffle Mushroom Risotto",
@@ -67,7 +82,7 @@ export function TodaySpecials() {
     },
   ];
 
-  const handleAddToCart = (item: any) => {
+  const handleAddToCart = (item: SpecialItem) => {
     addToCart(item);
   };
 

--- a/src/components/payment/DemoPayment.tsx
+++ b/src/components/payment/DemoPayment.tsx
@@ -10,7 +10,11 @@ import { formatIndianCurrency } from "@/lib/currency";
 
 interface DemoPaymentProps {
   amount: number;
-  onSuccess: (paymentDetails: any) => void;
+  onSuccess: (paymentDetails: {
+    razorpay_payment_id: string;
+    razorpay_order_id: string;
+    razorpay_signature: string;
+  }) => void;
   onCancel: () => void;
 }
 

--- a/src/components/payment/PaymentForm.tsx
+++ b/src/components/payment/PaymentForm.tsx
@@ -19,7 +19,11 @@ interface PaymentFormProps {
     email: string;
     requests: string;
   };
-  onPaymentSuccess: (paymentDetails: any) => void;
+  onPaymentSuccess: (paymentDetails: {
+    razorpay_payment_id: string;
+    razorpay_order_id: string;
+    razorpay_signature: string;
+  }) => void;
   onPaymentCancel: () => void;
   /** Optional: override total payable amount in INR (e.g., for cart checkout or pre-orders) */
   totalOverrideInInr?: number;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -4,26 +4,27 @@ import { Toaster as Sonner, toast } from "sonner"
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+	const { theme = "system" } = useTheme()
 
-  return (
-    <Sonner
-      theme={theme as ToasterProps["theme"]}
-      className="toaster group"
-      toastOptions={{
-        classNames: {
-          toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
-          actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-          cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
-        },
-      }}
-      {...props}
-    />
-  )
+	return (
+		<Sonner
+			theme={theme as ToasterProps["theme"]}
+			className="toaster group"
+			position="top-center"
+			toastOptions={{
+				classNames: {
+					toast:
+						"group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+					description: "group-[.toast]:text-muted-foreground",
+					actionButton:
+						"group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+					cancelButton:
+						"group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+				},
+			}}
+			{...props}
+		/>
+	)
 }
 
 export { Toaster, toast }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,7 +6,6 @@ import { TodaySpecials } from "@/components/home/TodaySpecials";
 import { RestaurantInfo } from "@/components/home/RestaurantInfo";
 import { Gallery } from "@/components/home/Gallery";
 import { Reviews } from "@/components/home/Reviews";
-import { CartSidebar } from "@/components/cart/CartSidebar";
 
 const Index = () => {
   return (
@@ -21,7 +20,6 @@ const Index = () => {
         <Reviews />
       </main>
       <Footer />
-      <CartSidebar />
     </div>
   );
 };

--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -11,7 +11,6 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { formatIndianCurrency } from "@/lib/currency";
 import { useNavigate } from "react-router-dom";
 import { useCart } from "@/contexts/CartContext";
-import { CartSidebar } from "@/components/cart/CartSidebar";
 import { ItemDetailDialog } from "@/components/menu/ItemDetailDialog";
 
 export default function Menu() {
@@ -374,7 +373,6 @@ export default function Menu() {
         onClose={() => setIsDialogOpen(false)}
       />
 
-      <CartSidebar />
       <Footer />
     </div>
   );


### PR DESCRIPTION
Move CartSidebar to the global app wrapper to display it on all pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1cd1c2d-009c-4b88-a969-9deae41d38d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1cd1c2d-009c-4b88-a969-9deae41d38d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

